### PR TITLE
Use fully qualified name for com.bolsinga.web.Record

### DIFF
--- a/src/com/bolsinga/diary/AltDocumentCreator.java
+++ b/src/com/bolsinga/diary/AltDocumentCreator.java
@@ -25,9 +25,9 @@ public class AltDocumentCreator extends DiaryRecordDocumentCreator {
     backgrounder.execute(backgroundable, new Runnable() {
       public void run() {
         create(new RecordFactory() {
-          public Vector<Record> getRecords() {
-            Vector<Record> items = new Vector<Record>(1);
-            items.add(Record.createRecordSimple(getAlt()));
+          public Vector<com.bolsinga.web.Record> getRecords() {
+            Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>(1);
+            items.add(com.bolsinga.web.Record.createRecordSimple(getAlt()));
             return items;
           }
           

--- a/src/com/bolsinga/diary/EntryRecordDocumentCreator.java
+++ b/src/com/bolsinga/diary/EntryRecordDocumentCreator.java
@@ -38,8 +38,8 @@ public class EntryRecordDocumentCreator extends DiaryEncoderRecordDocumentCreato
           final Entry first = group.firstElement();
           final String curName = fLinks.getPageFileName(first);
           create(new RecordFactory() {
-            public Vector<Record> getRecords() {
-              Vector<Record> records = new Vector<Record>();
+            public Vector<com.bolsinga.web.Record> getRecords() {
+              Vector<com.bolsinga.web.Record> records = new Vector<com.bolsinga.web.Record>();
               
               for (Vector<Entry> item : getMonthlies(group)) {
                 records.add(getEntryMonthRecordSection(item));
@@ -87,8 +87,8 @@ public class EntryRecordDocumentCreator extends DiaryEncoderRecordDocumentCreato
     return Collections.unmodifiableCollection(result.values());
   }
 
-  private Record getEntryMonthRecordSection(final Vector<Entry> entries) {
-    Vector<Record> items = new Vector<Record>();
+  private com.bolsinga.web.Record getEntryMonthRecordSection(final Vector<Entry> entries) {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>();
     
     // Note entries here is a Collection of Entrys in a single month
     String m = Util.getMonth(entries.firstElement());
@@ -97,15 +97,15 @@ public class EntryRecordDocumentCreator extends DiaryEncoderRecordDocumentCreato
       items.add(getEntryRecord(entry));
     }
 
-    return Record.createRecordSection(title, items);
+    return com.bolsinga.web.Record.createRecordSection(title, items);
   }
   
-  private Record getEntryRecord(final Entry entry) {
+  private com.bolsinga.web.Record getEntryRecord(final Entry entry) {
     return EntryRecordDocumentCreator.createEntryRecord(entry, fLinks, fEncoder, true);
   }
   
   // This is used for the main page and entry pages, which is why it is public static
-  public static Record createEntryRecord(final Entry entry, final Links links, final Encode encoder, final boolean upOneLevel) {
+  public static com.bolsinga.web.Record createEntryRecord(final Entry entry, final Links links, final Encode encoder, final boolean upOneLevel) {
     String title = entry.getTitle();
     if (title == null) {
         title = Util.getDisplayTitle(entry);
@@ -113,7 +113,7 @@ public class EntryRecordDocumentCreator extends DiaryEncoderRecordDocumentCreato
         Object[] args = { title, Util.getTimestamp(entry) };
         title = MessageFormat.format(Util.getResourceString("entrytitle"), args);
     }
-    return Record.createRecordPermalink(
+    return com.bolsinga.web.Record.createRecordPermalink(
       Util.createNamedTarget(entry.getID(), title), 
       encoder.embedLinks(entry, upOneLevel),
       Util.createPermaLink(links.getLinkTo(entry)));
@@ -123,9 +123,9 @@ public class EntryRecordDocumentCreator extends DiaryEncoderRecordDocumentCreato
     backgrounder.execute(backgroundable, new Runnable() {
       public void run() {
         create(new RecordFactory() {
-          public Vector<Record> getRecords() {
-            Vector<Record> items = new Vector<Record>(1);
-            items.add(Record.createRecordSimple(getStats()));
+          public Vector<com.bolsinga.web.Record> getRecords() {
+            Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>(1);
+            items.add(com.bolsinga.web.Record.createRecordSimple(getStats()));
             return items;
           }
 

--- a/src/com/bolsinga/diary/MainDocumentCreator.java
+++ b/src/com/bolsinga/diary/MainDocumentCreator.java
@@ -53,9 +53,9 @@ public class MainDocumentCreator extends DiaryEncoderRecordDocumentCreator {
     backgrounder.execute(backgroundable, new Runnable() {
       public void run() {
         create(new RecordFactory() {
-          public Vector<Record> getRecords() {
-            Vector<Record> items = new Vector<Record>(1);
-            items.add(Record.createRecordSimple(getMain()));
+          public Vector<com.bolsinga.web.Record> getRecords() {
+            Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>(1);
+            items.add(com.bolsinga.web.Record.createRecordSimple(getMain()));
             return items;
           }
           
@@ -202,7 +202,7 @@ public class MainDocumentCreator extends DiaryEncoderRecordDocumentCreator {
   private Element getDiary() {
     Div diaryDiv = Util.createDiv(CSS.DOC_SUB);
 
-// FIXME: Add Last Played Element here. Make a new Record.createRecord* w/ title and items
+// FIXME: Add Last Played Element here. Make a new com.bolsinga.web.Record.createRecord* w/ title and items
 // last played "<song title>"
 // by <artist> from <album>
 // on <date>

--- a/src/com/bolsinga/music/ArtistRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/ArtistRecordDocumentCreator.java
@@ -32,8 +32,8 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
           final Artist first = group.firstElement();
           final String curName = fLinks.getPageFileName(first);
           create(new RecordFactory() {
-            public Vector<Record> getRecords() {
-              Vector<Record> records = new Vector<Record>();
+            public Vector<com.bolsinga.web.Record> getRecords() {
+              Vector<com.bolsinga.web.Record> records = new Vector<com.bolsinga.web.Record>();
               
               for (Artist item : group) {
                 records.add(getArtistRecordSection(item));
@@ -149,16 +149,16 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
     return StatsRecordFactory.makeTable(names, values, tableTitle, typeString, Util.getResourceString("artiststatsummary"));
   }
   
-  private Record getArtistShowRecord(final Artist artist, final Show show) {
+  private com.bolsinga.web.Record getArtistShowRecord(final Artist artist, final Show show) {
     String dateString = Util.toString(show.getDate());
     
-    return Record.createRecordList(
+    return com.bolsinga.web.Record.createRecordList(
       Util.createInternalA(fLinks.getLinkTo(show), dateString, dateString), 
       getArtistShowListing(artist, show));
   }
   
-  private Record getArtistRecordSection(final Artist artist) {
-    Vector<Record> items = new Vector<Record>();
+  private com.bolsinga.web.Record getArtistRecordSection(final Artist artist) {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>();
 
     if (artist.getAlbums().size() > 0) {
       items.add(getAlbumRelations(artist));
@@ -177,7 +177,7 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
     
     A title = Util.createNamedTarget(artist.getID(), fLookup.getHTMLName(artist));
     
-    return Record.createRecordSection(title, items);
+    return com.bolsinga.web.Record.createRecordSection(title, items);
   }
   
   private Vector<Element> getArtistShowListing(final Artist artist, final Show show) {
@@ -240,13 +240,13 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
     return e;
   }
   
-  private Record getAlbumRelations(final Artist artist) {
-    return Record.createRecordList(
+  private com.bolsinga.web.Record getAlbumRelations(final Artist artist) {
+    return com.bolsinga.web.Record.createRecordList(
       new StringElement(Util.getResourceString("albums")), 
       getTracks(artist));
   }
 
-  private Record getArtistRelations(final Artist artist) {
+  private com.bolsinga.web.Record getArtistRelations(final Artist artist) {
         Vector<Element> e = new Vector<Element>();
         
         org.apache.ecs.Element curElement = null;
@@ -261,7 +261,7 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
           }
         }
 
-        return Record.createRecordList(
+        return com.bolsinga.web.Record.createRecordList(
           new StringElement(Util.getResourceString("seealso")),
           e,
           curElement);

--- a/src/com/bolsinga/music/ShowRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/ShowRecordDocumentCreator.java
@@ -37,8 +37,8 @@ public class ShowRecordDocumentCreator extends MusicRecordDocumentCreator {
           final Show first = group.firstElement();
           final String curName = fLinks.getPageFileName(first);
           create(new RecordFactory() {
-            public Vector<Record> getRecords() {
-              Vector<Record> records = new Vector<Record>();
+            public Vector<com.bolsinga.web.Record> getRecords() {
+              Vector<com.bolsinga.web.Record> records = new Vector<com.bolsinga.web.Record>();
               
               for (Vector<Show> item : getMonthlies(group)) {
                 records.add(getShowMonthRecordSection(item));
@@ -258,12 +258,12 @@ public class ShowRecordDocumentCreator extends MusicRecordDocumentCreator {
     });
   }
 
-  private Record getShowRecord(final Show show) {
+  private com.bolsinga.web.Record getShowRecord(final Show show) {
     return ShowRecordDocumentCreator.createShowRecord(show, fLinks, fLookup, fEncoder, false, true);
   }
   
   // This is used for the main page.
-  public static Record createShowRecord(final Show show, final Links links, final Lookup lookup, final Encode encoder, final boolean titleIsLink, final boolean upOneLevel) {
+  public static com.bolsinga.web.Record createShowRecord(final Show show, final Links links, final Lookup lookup, final Encode encoder, final boolean titleIsLink, final boolean upOneLevel) {
     Vector<Element> e = new Vector<Element>();
     StringBuilder sb = new StringBuilder();
     Iterator<? extends Artist> bi = show.getArtists().iterator();
@@ -297,11 +297,11 @@ public class ShowRecordDocumentCreator extends MusicRecordDocumentCreator {
     } else {
         title = Util.createNamedTarget(show.getID(), dateString);
     }
-    return Record.createRecordListWithComment(title, e, comment);
+    return com.bolsinga.web.Record.createRecordListWithComment(title, e, comment);
   }
 
-  private Record getShowMonthRecordSection(final Vector<Show> shows) {
-    Vector<Record> items = new Vector<Record>();
+  private com.bolsinga.web.Record getShowMonthRecordSection(final Vector<Show> shows) {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>();
 
     // Note shows here is a Collection of Shows in a single month
     String name;
@@ -317,7 +317,7 @@ public class ShowRecordDocumentCreator extends MusicRecordDocumentCreator {
       items.add(getShowRecord(show));
     }
 
-    return Record.createRecordSection(title, items);
+    return com.bolsinga.web.Record.createRecordSection(title, items);
   }
   
   private Element getLinkToShowMonthYear(final String year, final int month, final String value) {

--- a/src/com/bolsinga/music/StatsRecordFactory.java
+++ b/src/com/bolsinga/music/StatsRecordFactory.java
@@ -9,9 +9,9 @@ import org.apache.ecs.html.*;
 
 public abstract class StatsRecordFactory implements RecordFactory {
 
-  public Vector<Record> getRecords() {
-    Vector<Record> items = new Vector<Record>(1);
-    items.add(Record.createRecordSimple(getTable()));
+  public Vector<com.bolsinga.web.Record> getRecords() {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>(1);
+    items.add(com.bolsinga.web.Record.createRecordSimple(getTable()));
     return items;
   }
 

--- a/src/com/bolsinga/music/TracksRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/TracksRecordDocumentCreator.java
@@ -32,8 +32,8 @@ public class TracksRecordDocumentCreator extends MusicRecordDocumentCreator {
           final Album first = group.firstElement();
           final String curName = fLinks.getPageFileName(first);
           create(new RecordFactory() {
-            public Vector<Record> getRecords() {
-              Vector<Record> records = new Vector<Record>();
+            public Vector<com.bolsinga.web.Record> getRecords() {
+              Vector<com.bolsinga.web.Record> records = new Vector<com.bolsinga.web.Record>();
               
               for (Album item : group) {
                 records.add(getAlbumRecordSection(item));
@@ -270,9 +270,9 @@ public class TracksRecordDocumentCreator extends MusicRecordDocumentCreator {
     return new StringElement(sb.toString());
   }
   
-  private Record getAlbumRecordSection(final Album album) {
-    Vector<Record> items = new Vector<Record>(1);
-    items.add(Record.createRecordListOrdered(null, getAlbumListing(album)));
-    return Record.createRecordSection(getAlbumTitle(album), items);
+  private com.bolsinga.web.Record getAlbumRecordSection(final Album album) {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>(1);
+    items.add(com.bolsinga.web.Record.createRecordListOrdered(null, getAlbumListing(album)));
+    return com.bolsinga.web.Record.createRecordSection(getAlbumTitle(album), items);
   }
 }

--- a/src/com/bolsinga/music/VenueRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/VenueRecordDocumentCreator.java
@@ -32,8 +32,8 @@ public class VenueRecordDocumentCreator extends MusicRecordDocumentCreator {
           final Venue first = group.firstElement();
           final String curName = fLinks.getPageFileName(first);
           create(new RecordFactory() {
-            public Vector<Record> getRecords() {
-              Vector<Record> records = new Vector<Record>();
+            public Vector<com.bolsinga.web.Record> getRecords() {
+              Vector<com.bolsinga.web.Record> records = new Vector<com.bolsinga.web.Record>();
               
               for (Venue item : group) {
                 records.add(getVenueRecordSection(item));
@@ -174,18 +174,18 @@ public class VenueRecordDocumentCreator extends MusicRecordDocumentCreator {
     return e;
   }
   
-  private Record getVenueShowRecord(final Venue venue, final Show show) {
+  private com.bolsinga.web.Record getVenueShowRecord(final Venue venue, final Show show) {
     String dateString = Util.toString(show.getDate());
-    return Record.createRecordList(
+    return com.bolsinga.web.Record.createRecordList(
       Util.createInternalA(fLinks.getLinkTo(show), dateString, dateString), 
       getVenueShowListing(venue, show));
   }
   
-  private Record getVenueRecordSection(final Venue venue) {
-    Vector<Record> items = new Vector<Record>();
+  private com.bolsinga.web.Record getVenueRecordSection(final Venue venue) {
+    Vector<com.bolsinga.web.Record> items = new Vector<com.bolsinga.web.Record>();
 
     Location l = venue.getLocation();
-    items.add(Record.createRecordSimple(Util.createExternalA(Util.getGoogleMapsURL(l), Util.getCannonicalAddress(l))));
+    items.add(com.bolsinga.web.Record.createRecordSimple(Util.createExternalA(Util.getGoogleMapsURL(l), Util.getCannonicalAddress(l))));
     
     if (fLookup.getRelations(venue) != null) {
       items.add(getVenueRelations(venue));
@@ -206,10 +206,10 @@ public class VenueRecordDocumentCreator extends MusicRecordDocumentCreator {
       title = Util.createNamedTarget(venue.getID(), fLookup.getHTMLName(venue));
     }
     
-    return Record.createRecordSection(title, items);
+    return com.bolsinga.web.Record.createRecordSection(title, items);
   }
 
-  private Record getVenueRelations(final Venue venue) {
+  private com.bolsinga.web.Record getVenueRelations(final Venue venue) {
         Vector<Element> e = new Vector<Element>();
         
         org.apache.ecs.Element curElement = null;
@@ -224,7 +224,7 @@ public class VenueRecordDocumentCreator extends MusicRecordDocumentCreator {
           }
         }
 
-        return Record.createRecordList(
+        return com.bolsinga.web.Record.createRecordList(
           new StringElement(Util.getResourceString("seealso")),
           e, 
           curElement);

--- a/src/com/bolsinga/web/Record.java
+++ b/src/com/bolsinga/web/Record.java
@@ -15,9 +15,9 @@ import org.apache.ecs.html.*;
 public class Record {
   private final Element fElement;
   
-  public static Record createRecordSection(final Element title, final Vector<Record> items) {
+  public static com.bolsinga.web.Record createRecordSection(final Element title, final Vector<com.bolsinga.web.Record> items) {
     Vector<Element> e = new Vector<Element>(items.size());
-    for (Record item : items) {
+    for (com.bolsinga.web.Record item : items) {
       e.add(item.getElement());
     }
     
@@ -26,50 +26,50 @@ public class Record {
       eTitle = new H2().addElement(title);
     }
     
-    return new Record(CSS.RECORD_SECTION, eTitle, Util.createUnorderedList(e), null, null);
+    return new com.bolsinga.web.Record(CSS.RECORD_SECTION, eTitle, Util.createUnorderedList(e), null, null);
   }
   
-  public static Record createRecordList(final Element title, final Vector<Element> items) {
-    return Record.createRecordList(title, items, null);
+  public static com.bolsinga.web.Record createRecordList(final Element title, final Vector<Element> items) {
+    return com.bolsinga.web.Record.createRecordList(title, items, null);
   }
   
-  public static Record createRecordList(final Element title, final Vector<Element> items, final Element curElement) {
-    return Record.createRecordListWithComment(title, items, curElement, null);
+  public static com.bolsinga.web.Record createRecordList(final Element title, final Vector<Element> items, final Element curElement) {
+    return com.bolsinga.web.Record.createRecordListWithComment(title, items, curElement, null);
   }
   
-  public static Record createRecordListWithComment(final Element title, final Vector<Element> items, final String comment) {
-    return Record.createRecordListWithComment(title, items, null, comment);
+  public static com.bolsinga.web.Record createRecordListWithComment(final Element title, final Vector<Element> items, final String comment) {
+    return com.bolsinga.web.Record.createRecordListWithComment(title, items, null, comment);
   }
   
-  private static Record createRecordListWithComment(final Element title, final Vector<Element> items, final Element curElement, final String comment) {
+  private static com.bolsinga.web.Record createRecordListWithComment(final Element title, final Vector<Element> items, final Element curElement, final String comment) {
     Element eTitle = null;
     if (title != null) {
       eTitle = new H3().addElement(title);
     }
 
-    return new Record(CSS.RECORD_ITEM_LIST, eTitle, Util.createUnorderedList(items, curElement), comment, null);
+    return new com.bolsinga.web.Record(CSS.RECORD_ITEM_LIST, eTitle, Util.createUnorderedList(items, curElement), comment, null);
   }
   
-  public static Record createRecordListOrdered(final Element title, final Vector<Element> items) {
+  public static com.bolsinga.web.Record createRecordListOrdered(final Element title, final Vector<Element> items) {
     Element eTitle = null;
     if (title != null) {
       eTitle = new H3().addElement(title);
     }
 
-    return new Record(CSS.RECORD_ITEM_LIST, eTitle, Util.createOrderedList(items), null, null);
+    return new com.bolsinga.web.Record(CSS.RECORD_ITEM_LIST, eTitle, Util.createOrderedList(items), null, null);
   }
   
-  public static Record createRecordSimple(final Element element) {
-    return new Record(element);
+  public static com.bolsinga.web.Record createRecordSimple(final Element element) {
+    return new com.bolsinga.web.Record(element);
   }
   
-  public static Record createRecordPermalink(final Element title, final String comment, final A permalink) {
+  public static com.bolsinga.web.Record createRecordPermalink(final Element title, final String comment, final A permalink) {
     Element eTitle = null;
     if (title != null) {
       eTitle = new H3().addElement(title);
     }
 
-    return new Record(CSS.RECORD_ITEM_LIST, eTitle, null, comment, permalink);
+    return new com.bolsinga.web.Record(CSS.RECORD_ITEM_LIST, eTitle, null, comment, permalink);
   }
   
   private Record(final String divClass, final Element title, final Element items, final String comment, final A permaLink) {

--- a/src/com/bolsinga/web/RecordDocumentCreator.java
+++ b/src/com/bolsinga/web/RecordDocumentCreator.java
@@ -44,8 +44,8 @@ public abstract class RecordDocumentCreator implements Backgroundable {
     
     Div main = Util.createDiv(getMainDivClass());
         
-    Vector<Record> records = factory.getRecords();
-    for (Record record : records) {
+    Vector<com.bolsinga.web.Record> records = factory.getRecords();
+    for (com.bolsinga.web.Record record : records) {
       main.addElement(record.getElement());
     }
     

--- a/src/com/bolsinga/web/RecordFactory.java
+++ b/src/com/bolsinga/web/RecordFactory.java
@@ -10,7 +10,7 @@ package com.bolsinga.web;
 import java.util.*;
 
 public interface RecordFactory {
-  public Vector<Record> getRecords();
+  public Vector<com.bolsinga.web.Record> getRecords();
   public String getTitle();
   public String getFilePath();
   public Navigator getNavigator();


### PR DESCRIPTION
- Command: `git grep -rwl Record src/ | xargs sed -i '' -e's|[[:<:]]Record[[:>:]]|com.bolsinga.web.Record|g'`
- Java14 has made `java.land.Record` a regular class, so workaround the ambiguity by using a fully qualified name.