### PR TITLE
Sort parsed itunes albums for consistency

### DIFF
--- a/src/com/bolsinga/itunes/Parser.java
+++ b/src/com/bolsinga/itunes/Parser.java
@@ -17,7 +17,7 @@ public class Parser {
   private final HashMap<String, Artist> fArtistMap = new HashMap<String, Artist>();
   
   // AlbumKey -> Album
-  private final HashMap<String, Album> fAlbumMap = new HashMap<String, Album>();
+  private final Map<String, Album> fAlbumMap = new TreeMap<String, Album>();
   
   // AlbumKey's
   private final HashSet<String> fArtistAlbumSet = new HashSet<String>();


### PR DESCRIPTION
This will ensure that the album IDs, which are created sequentially, will be consistent between different sources of data, ie JSON vs XML itunes. This is because those files are not in the same order. Sorting this makes them consistent with each other.