### PR TITLE
Add Convert XML to JSON Tool

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -190,6 +190,9 @@
   <exec executable="cp" >
     <arg line="${src.dir}/scripts/albums ${dst.dir}" />
   </exec>
+  <exec executable="cp" >
+    <arg line="${src.dir}/scripts/convert ${dst.dir}" />
+  </exec>
   <copy file="${build.lib}/${ant.project.name}.jar" todir="${dst.lib}" />
   <copy file="${lib.dir}/ecs-1.4.2.jar" todir="${dst.lib}" />
   <copy file="${lib.dir}/json-20200518.jar" todir="${dst.lib}" />

--- a/src/com/bolsinga/itunes/Convert.java
+++ b/src/com/bolsinga/itunes/Convert.java
@@ -1,0 +1,60 @@
+package com.bolsinga.itunes;
+
+import java.util.*;
+import org.json.*;
+
+public class Convert {
+
+  public static void main(String[] args) {
+    if (args.length != 1) {
+      Convert.usage(args, "Wrong number of arguments");
+    }
+
+    int i = 0;
+    String itunesXML = args[i++];
+
+    List<Track> xmlTracks = null;
+
+    try {
+      Parser xmlParser = new Parser();
+      try {
+        xmlTracks = xmlParser.parseTracks(itunesXML);
+      } catch (ParserException e) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Can't parse iTunes XML file: ");
+        sb.append(itunesXML);
+        throw new com.bolsinga.web.WebException(sb.toString(), e);
+      }
+    } catch (Exception e) {
+      System.err.println(e.toString());
+      System.exit(1);
+    }
+
+    JSONArray jsonArray = new JSONArray(/*xmlTracks.size()*/);
+
+    for (Track track : xmlTracks) {
+      JSONObject jsonTrack = JSONParser.convert(track);
+      if (jsonTrack != null) {
+        jsonArray.put(jsonTrack);
+      }
+    }
+
+    if (jsonArray.length() > 0) {
+      String jsonString = jsonArray.toString(2);
+      System.out.println(jsonString);
+    }
+  }
+
+  private static void usage(final String[] badargs, final String reason) {
+    System.out.println("Usage: Convert [iTunes Music.xml]");
+    System.out.println(reason);
+    if (badargs != null) {
+      System.out.println("Arguments:");
+      for (int i = 0; i < badargs.length; i++) {
+        System.out.print(badargs[i] + " ");
+      }
+    }
+    System.out.println();
+    System.exit(1);
+  }
+}

--- a/src/com/bolsinga/itunes/JSONParser.java
+++ b/src/com/bolsinga/itunes/JSONParser.java
@@ -180,4 +180,71 @@ class JSONParser {
     }
     return knownKey;
   }
+
+  static JSONObject convert(final Track track) {
+    JSONObject json = new JSONObject();
+
+    if (track.getAlbum() != null && track.getAlbum().length() > 0) { json.put(ALBUM, track.getAlbum()); }
+    if (track.getArtist() != null && track.getArtist().length() > 0) { json.put(ARTIST, track.getArtist()); }
+    if (track.getArtwork_Count() != null && track.getArtwork_Count().length() > 0) { json.put(ARTWORKCOUNT, track.getArtwork_Count()); }
+    if (track.getBit_Rate() != null && track.getBit_Rate().length() > 0) { json.put(BITRATE, track.getBit_Rate()); }
+    if (track.getComments() != null && track.getComments().length() > 0) { json.put(COMMENTS, track.getComments()); }
+    if (track.getCompilation() != null && track.getCompilation().length() > 0) { json.put(COMPILATION, track.getCompilation()); }
+    if (track.getComposer() != null && track.getComposer().length() > 0) { json.put(COMPOSER, track.getComposer()); }
+    if (track.getDate_Added() != null && track.getDate_Added().length() > 0) { json.put(DATEADDED, track.getDate_Added()); }
+    if (track.getDate_Modified() != null && track.getDate_Modified().length() > 0) { json.put(DATEMODIFIED, track.getDate_Modified()); }
+    if (track.getDisc_Count() != null && track.getDisc_Count().length() > 0) { json.put(DISCCOUNT, track.getDisc_Count()); }
+    if (track.getDisc_Number() != null && track.getDisc_Number().length() > 0) { json.put(DISCNUMBER, track.getDisc_Number()); }
+    if (track.getGenre() != null && track.getGenre().length() > 0) { json.put(GENRE, track.getGenre()); }
+    if (track.getKind() != null && track.getKind().length() > 0) { json.put(KIND, track.getKind()); }
+    if (track.getLocation() != null && track.getLocation().length() > 0) { json.put(LOCATION, track.getLocation()); }
+    if (track.getName() != null && track.getName().length() > 0) { json.put(NAME, track.getName()); }
+    if (track.getPlay_Count() != null && track.getPlay_Count().length() > 0) { json.put(PLAYCOUNT, track.getPlay_Count()); }
+    if (track.getPlay_Date_UTC() != null && track.getPlay_Date_UTC().length() > 0) { json.put(PLAYDATEUTC, track.getPlay_Date_UTC()); }
+    if (track.getSample_Rate() != null && track.getSample_Rate().length() > 0) { json.put(SAMPLERATE, track.getSample_Rate()); }
+    if (track.getSize() != null && track.getSize().length() > 0) { json.put(SIZE, track.getSize()); }
+    if (track.getTotal_Time() != null && track.getTotal_Time().length() > 0) { json.put(TOTALTIME, track.getTotal_Time()); }
+    if (track.getTrack_Count() != null && track.getTrack_Count().length() > 0) { json.put(TRACKCOUNT, track.getTrack_Count()); }
+    if (track.getTrack_Number() != null && track.getTrack_Number().length() > 0) { json.put(TRACKNUMBER, track.getTrack_Number()); }
+    if (track.getTrack_Type() != null && track.getTrack_Type().length() > 0) { json.put(TRACKTYPE, track.getTrack_Type()); }
+    if (track.getYear() != null && track.getYear().length() > 0) { json.put(YEAR, track.getYear()); }
+    if (track.getSeason() != null && track.getSeason().length() > 0) { json.put(SEASON, track.getSeason()); }
+    if (track.getPersistent_ID() != null && track.getPersistent_ID().length() > 0) { json.put(PERSISTENTID, track.getPersistent_ID()); }
+    if (track.getSeries() != null && track.getSeries().length() > 0) { json.put(SERIES, track.getSeries()); }
+    if (track.getEpisode() != null && track.getEpisode().length() > 0) { json.put(EPISODE, track.getEpisode()); }
+    if (track.getEpisode_Order() != null && track.getEpisode_Order().length() > 0) { json.put(EPISODEORDER, track.getEpisode_Order()); }
+    if (track.getHas_Video() != null && track.getHas_Video().length() > 0) { json.put(HASVIDEO, track.getHas_Video()); }
+    if (track.getTV_Show() != null && track.getTV_Show().length() > 0) { json.put(TVSHOW, track.getTV_Show()); }
+    if (track.getProtected() != null && track.getProtected().length() > 0) { json.put(PROTECTED, track.getProtected()); }
+    if (track.getBPM() != null && track.getBPM().length() > 0) { json.put(BPM, track.getBPM()); }
+    if (track.getAlbum_Artist() != null && track.getAlbum_Artist().length() > 0) { json.put(ALBUMARTIST, track.getAlbum_Artist()); }
+    if (track.getExplicit() != null && track.getExplicit().length() > 0) { json.put(EXPLICIT, track.getExplicit()); }
+    if (track.getSkip_Count() != null && track.getSkip_Count().length() > 0) { json.put(SKIPCOUNT, track.getSkip_Count()); }
+    if (track.getSkip_Date() != null && track.getSkip_Date().length() > 0) { json.put(SKIPDATE, track.getSkip_Date()); }
+    if (track.getRelease_Date() != null && track.getRelease_Date().length() > 0) { json.put(RELEASEDATE, track.getRelease_Date()); }
+    if (track.getPodcast() != null && track.getPodcast().length() > 0) { json.put(PODCAST, track.getPodcast()); }
+    if (track.getMovie() != null && track.getMovie().length() > 0) { json.put(MOVIE, track.getMovie()); }
+    if (track.getUnplayed() != null && track.getUnplayed().length() > 0) { json.put(UNPLAYED, track.getUnplayed()); }
+    if (track.getSort_Album() != null && track.getSort_Album().length() > 0) { json.put(SORTALBUM, track.getSort_Album()); }
+    if (track.getSort_Album_Artist() != null && track.getSort_Album_Artist().length() > 0) { json.put(SORTALBUMARTIST, track.getSort_Album_Artist()); }
+    if (track.getSort_Artist() != null && track.getSort_Artist().length() > 0) { json.put(SORTARTIST, track.getSort_Artist()); }
+    if (track.getSort_Composer() != null && track.getSort_Composer().length() > 0) { json.put(SORTCOMPOSER, track.getSort_Composer()); }
+    if (track.getSort_Name() != null && track.getSort_Name().length() > 0) { json.put(SORTNAME, track.getSort_Name()); }
+    if (track.getContent_Rating() != null && track.getContent_Rating().length() > 0) { json.put(CONTENTRATING, track.getContent_Rating()); }
+    if (track.getDisabled() != null && track.getDisabled().length() > 0) { json.put(DISABLED, track.getDisabled()); }
+    if (track.getPurchased() != null && track.getPurchased().length() > 0) { json.put(PURCHASED, track.getPurchased()); }
+    if (track.getVideo_Height() != null && track.getVideo_Height().length() > 0) { json.put(VIDEOHEIGHT, track.getVideo_Height()); }
+    if (track.getVideo_Width() != null && track.getVideo_Width().length() > 0) { json.put(VIDEOWIDTH, track.getVideo_Width()); }
+    if (track.getHD() != null && track.getHD().length() > 0) { json.put(HD, track.getHD()); }
+    if (track.getAlbum_Rating() != null && track.getAlbum_Rating().length() > 0) { json.put(ALBUMRATING, track.getAlbum_Rating()); }
+    if (track.getAlbum_Rating_Computed() != null && track.getAlbum_Rating_Computed().length() > 0) { json.put(ALBUMRATINGCOMPUTED, track.getAlbum_Rating_Computed()); }
+    if (track.getRating() != null && track.getRating().length() > 0) { json.put(RATING, track.getRating()); }
+    if (track.getGrouping() != null && track.getGrouping().length() > 0) { json.put(GROUPING, track.getGrouping()); }
+    if (track.getPart_Of_Gapless_Album() != null && track.getPart_Of_Gapless_Album().length() > 0) { json.put(PARTOFGAPLESSALBUM, track.getPart_Of_Gapless_Album()); }
+    if (track.getMusic_Video() != null && track.getMusic_Video().length() > 0) { json.put(MUSICVIDEO, track.getMusic_Video()); }
+    if (track.getRating_Computed() != null && track.getRating_Computed().length() > 0) { json.put(RATINGCOMPUTED, track.getRating_Computed()); }
+    if (track.getSort_Series() != null && track.getSort_Series().length() > 0) { json.put(SORTSERIES, track.getSort_Series()); }
+
+    return json;
+  }
 }

--- a/src/scripts/convert
+++ b/src/scripts/convert
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+usage()
+{
+    echo "convert itunes.xml"
+    echo $1
+    exit 1
+}
+
+if [ $# -eq 0 ] ; then
+        usage "No arguments"
+fi
+
+if [ -n "$JAVA_HOME" ] ; then
+    JAVA_CMD="$JAVA_HOME/bin/java"
+else
+    JAVA_CMD=`which java 2> /dev/null`
+fi
+
+PRG="$0"
+PROG_HOME=`dirname "$PRG"`
+PROG_HOME=`cd "$PROG_HOME" && pwd`
+
+SITE_LIB_DIR="$PROG_HOME/lib"
+if [ ! -d "${SITE_LIB_DIR}" ] ; then
+    usage "Can't find ${SITE_LIB_DIR}"
+fi
+
+for i in "${SITE_LIB_DIR}" ; do
+    for j in "${i}"/*.jar; do
+        if [ -z "$LOCAL_CLASSPATH" ] ; then
+            LOCAL_CLASSPATH="$j"
+        else
+            LOCAL_CLASSPATH="$LOCAL_CLASSPATH:$j"
+        fi
+    done
+done
+
+ITUNES_XML="$1"
+if [ -z "$ITUNES_XML" ] ; then
+    usage "No itunes.xml"
+fi
+
+COMMAND="exec \"$JAVA_CMD\" -Xms256m -Xmx256m -ea:com.bolsinga..."
+if [ ! -z "$JAVA_OPTS" ] ; then
+    COMMAND="$COMMAND $JAVA_OPTS"
+fi
+COMMAND="$COMMAND -classpath \"$LOCAL_CLASSPATH\" com.bolsinga.itunes.Convert $ITUNES_XML"
+
+if [ ! -z "$DUMP" ] ; then
+    echo "$COMMAND"
+    exit 0
+fi
+
+eval $COMMAND


### PR DESCRIPTION
- This will convert a given iTunes XML file to json using the same keys and values as the https://github.com/bolsinga/itunes_json tool.
- This way old iTunes XML backup files can be converted to modern json formats for future data mining.