### PR TITLE
Improve Similar Artists Diagnostic Output

### DIFF
--- a/src/com/bolsinga/site/Main.java
+++ b/src/com/bolsinga/site/Main.java
@@ -135,20 +135,21 @@ public class Main implements Backgroundable {
 
   private void dumpSimilarArtists(final com.bolsinga.music.data.Music music) {
     String s;
-    HashSet<String> bands = new HashSet<String>();
+    HashMap<String, com.bolsinga.music.data.Artist> bands = new HashMap<String, com.bolsinga.music.data.Artist>();
     boolean displayed = false;
     
     List<? extends com.bolsinga.music.data.Artist> artists = music.getArtists();
     for (com.bolsinga.music.data.Artist artist : artists) {
       s = com.bolsinga.music.Compare.simplify(artist.getName());
-      if (bands.contains(s)) {
+      if (bands.containsKey(s)) {
         if (!displayed) {
           System.out.println("--Similar Artist Names--");
           displayed = true;
         }
-        System.out.println(s);
+        com.bolsinga.music.data.Artist existingArtist = bands.get(s);
+        System.out.println("Existing: " + existingArtist.getName() + " Duplicate: " + artist.getName() + " Simplified: " + s);
       } else {
-        bands.add(s);
+        bands.put(s, artist);
       }
     }
   }


### PR DESCRIPTION
This is looking for names that are similar. Basically it was looking for artists like "The Beatles" entered as "Beatles". Then I'd find and fix those.

HOWEVER -> Osees change their name and sometimes they are "Thee Oh Sees" and sometimes "Oh Sees". Also I have a album by "Girls" but have seen a band called "The Girls". Perhaps "Girls" are the same?

Regardless, both artists appear in the output OK, and these are the last that log for me now.