### PR TITLE
Add sort name property to Venue

### DIFF
--- a/src/com/bolsinga/music/Compare.java
+++ b/src/com/bolsinga/music/Compare.java
@@ -11,7 +11,6 @@ import com.bolsinga.web.*;
 public class Compare {
 
   private static final String THE  = "the ";
-  private static final String THEE = "thee ";
   private static final String A    = "a ";
   private static final String AN   = "an ";
     
@@ -53,10 +52,7 @@ public class Compare {
     if (lower.startsWith(AN)) {
       lower = lower.substring(AN.length(), len);
     }
-    if (lower.startsWith(THEE)) {
-      lower = lower.substring(THEE.length(), len);
-    }
-                
+
     Matcher m = sChomp.matcher(lower);
     String result = m.replaceFirst("");
     if ((result != null) && (result.length() > 0)) {
@@ -86,7 +82,16 @@ public class Compare {
         
   public static final Comparator<Venue> VENUE_COMPARATOR = new Comparator<Venue>() {
       public int compare(final Venue r1, final Venue r2) {
-        return LIBRARY_COMPARATOR.compare(r1.getName(), r2.getName());
+        String n1 = r1.getSortname();
+        if (n1 == null) {
+          n1 = r1.getName();
+        }
+        String n2 = r2.getSortname();
+        if (n2 == null) {
+          n2 = r2.getName();
+        }
+
+        return LIBRARY_COMPARATOR.compare(n1, n2);
       }
     };
         

--- a/src/com/bolsinga/music/data/Venue.java
+++ b/src/com/bolsinga/music/data/Venue.java
@@ -8,4 +8,6 @@ public interface Venue {
   public Location getLocation();
   public String getComment();
   public void setComment(final String comment);
+  public String getSortname();
+  public void setSortname(final String name);
 }

--- a/src/com/bolsinga/music/data/json/Venue.java
+++ b/src/com/bolsinga/music/data/json/Venue.java
@@ -9,11 +9,13 @@ public class Venue implements com.bolsinga.music.data.Venue {
   private static final String NAME = "name";
   private static final String LOCATION = "location";
   private static final String COMMENT = "comment";
+  private static final String SORTNAME = "sortname";
 
   private String id;
   private String name;
   private Location location = null;
   private String comment = null;
+  private String sortname = null;
   
   private static final Map<String, Venue> sMap = new HashMap<String, Venue>();
   
@@ -59,6 +61,10 @@ public class Venue implements com.bolsinga.music.data.Venue {
     if (comment != null) {
       json.put(COMMENT, comment);
     }
+    String sortname = venue.getSortname();
+    if (sortname != null) {
+      json.put(SORTNAME, sortname);
+    }
     
     return json;
   }
@@ -82,6 +88,7 @@ public class Venue implements com.bolsinga.music.data.Venue {
       location = Location.create(optJSON);
     }
     comment = json.optString(COMMENT, null);
+    sortname = json.optString(SORTNAME, null);
   }
   
   public String getID() {
@@ -110,5 +117,13 @@ public class Venue implements com.bolsinga.music.data.Venue {
   
   public void setComment(final String comment) {
     this.comment = comment;
+  }
+
+  public String getSortname() {
+    return sortname;
+  }
+
+  public void setSortname(final String name) {
+    this.sortname = name;
   }
 }

--- a/src/com/bolsinga/music/data/raw/Venue.java
+++ b/src/com/bolsinga/music/data/raw/Venue.java
@@ -11,12 +11,13 @@ public class Venue implements com.bolsinga.music.data.Venue {
   private String fName;
   private Location fLocation;
   private String fComment;
+  private String fSortname;
   
   static List<Venue> create(final String filename) throws com.bolsinga.web.WebException {
     try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(filename), "UTF8"))) {
       String s = null;
       StringTokenizer st = null;
-      String name, city, state, address, url;
+      String name, city, state, address, url, sortname;
       try {
         while ((s = in.readLine()) != null) {
           st = new StringTokenizer(s, "*");
@@ -37,7 +38,13 @@ public class Venue implements com.bolsinga.music.data.Venue {
             url = null;
           }
           
-          Venue v = new Venue(name, Location.create(address, city, state, url));
+          if (st.hasMoreElements()) {
+            sortname = st.nextToken();
+          } else {
+            sortname = null;
+          }
+
+          Venue v = new Venue(name, Location.create(address, city, state, url), sortname);
 
           sMap.put(name, v);
         }
@@ -84,9 +91,10 @@ public class Venue implements com.bolsinga.music.data.Venue {
     }
   }
   
-  private Venue(final String name, final Location location) {
+  private Venue(final String name, final Location location, final String sortname) {
     fName = name;
     fLocation = location;
+    fSortname = sortname;
   }
   
   public String getID() {
@@ -116,5 +124,13 @@ public class Venue implements com.bolsinga.music.data.Venue {
   
   public void setComment(final String comment) {
     fComment = comment;
+  }
+
+  public String getSortname() {
+    return fSortname;
+  }
+
+  public void setSortname(final String name) {
+    fSortname = name;
   }
 }

--- a/src/com/bolsinga/web/Links.java
+++ b/src/com/bolsinga/web/Links.java
@@ -108,7 +108,11 @@ public class Links {
   }
         
   public String getPageFileName(final Venue venue) {
-    return getPageFileName(venue.getName());
+    String name = venue.getSortname();
+    if (name == null) {
+      name = venue.getName();
+    }
+    return getPageFileName(name);
   }
         
   public String getPageFileName(final Show show) {


### PR DESCRIPTION
"Thee Parkside" will still sort properly when the data is updated.

This allows "THEE" to be removed from the simplified name comparison for `LIBRARY_COMPARATOR`. "The" and "A" are still dropped when sorting names. "Oh Sees" & "Thee Oh Sees" were related, but not showing properly due to the simplified name sort.

Investigated by changing the settings.property `embedLinks` to false as well as passing `JAVA_OPTS='-Dweb.debug_output=true'` to the command line tool.