### PR TITLE
Add redirect files for Artist, Venue, Show.

### DIFF
--- a/src/com/bolsinga/music/ArtistRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/ArtistRecordDocumentCreator.java
@@ -37,6 +37,19 @@ public class ArtistRecordDocumentCreator extends MusicRecordDocumentCreator {
               
               for (Artist item : group) {
                 records.add(getArtistRecordSection(item));
+
+                backgrounder.execute(backgroundable, new Runnable() {
+                  public void run() {
+                    createRedirectDocument(new RedirectFactory() {
+                      public String getInternalURL() {
+                        return fLinks.getInternalLinkTo(item);
+                      }
+                      public String getFilePath() {
+                        return fLinks.getIdentifierPath(item);
+                      }
+                    });
+                  }
+                });
               }
               
               return records;

--- a/src/com/bolsinga/music/ShowRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/ShowRecordDocumentCreator.java
@@ -40,6 +40,21 @@ public class ShowRecordDocumentCreator extends MusicRecordDocumentCreator {
               
               for (Vector<Show> item : getMonthlies(group)) {
                 records.add(getShowMonthRecordSection(item));
+
+                for (Show show : item) {
+                  backgrounder.execute(backgroundable, new Runnable() {
+                    public void run() {
+                      createRedirectDocument(new RedirectFactory() {
+                        public String getInternalURL() {
+                          return fLinks.getInternalLinkTo(show);
+                        }
+                        public String getFilePath() {
+                          return fLinks.getIdentifierPath(show);
+                        }
+                      });
+                    }
+                  });
+                }
               }
               
               return records;

--- a/src/com/bolsinga/music/VenueRecordDocumentCreator.java
+++ b/src/com/bolsinga/music/VenueRecordDocumentCreator.java
@@ -37,6 +37,19 @@ public class VenueRecordDocumentCreator extends MusicRecordDocumentCreator {
               
               for (Venue item : group) {
                 records.add(getVenueRecordSection(item));
+
+                backgrounder.execute(backgroundable, new Runnable() {
+                  public void run() {
+                    createRedirectDocument(new RedirectFactory() {
+                      public String getInternalURL() {
+                        return fLinks.getInternalLinkTo(item);
+                      }
+                      public String getFilePath() {
+                        return fLinks.getIdentifierPath(item);
+                      }
+                    });
+                  }
+                });
               }
               
               return records;

--- a/src/com/bolsinga/web/Links.java
+++ b/src/com/bolsinga/web/Links.java
@@ -162,6 +162,36 @@ public class Links {
     return sb.toString();
   }
 
+  // This is the path for the file with the identifier that redirects into the grouped page.
+  public String getIdentifierPath(final Artist artist) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(ARTIST_DIR);
+    sb.append(File.separator);
+    sb.append(artist.getID());
+    sb.append(HTML_EXT);
+    return sb.toString();
+  }
+
+  // This is the path for the file with the identifier that redirects into the grouped page.
+  public String getIdentifierPath(final Venue venue) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(VENUE_DIR);
+    sb.append(File.separator);
+    sb.append(venue.getID());
+    sb.append(HTML_EXT);
+    return sb.toString();
+  }
+
+  // This is the path for the file with the identifier that redirects into the grouped page.
+  public String getIdentifierPath(final Show show) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(SHOW_DIR);
+    sb.append(File.separator);
+    sb.append(show.getID());
+    sb.append(HTML_EXT);
+    return sb.toString();
+  }
+
   public String getLinkToPage(final Artist artist) {
     StringBuilder sb = new StringBuilder();
     sb.append(getDirectoryPath(ARTIST_DIR));
@@ -201,32 +231,63 @@ public class Links {
     return sb.toString();
   }
 
-  public String getLinkTo(final Artist artist) {
+  // These are the internal links, not shared. They go to the named anchor on the page.
+  public String getInternalLinkTo(final Artist artist) {
     StringBuilder sb = new StringBuilder();
                 
     sb.append(getLinkToPage(artist));
     sb.append(HASH);
     sb.append(artist.getID());
-                
     return sb.toString();
   }
-        
-  public String getLinkTo(final Venue venue) {
+
+  // These are the internal links, not shared. They go to the named anchor on the page.
+  public String getInternalLinkTo(final Venue venue) {
     StringBuilder sb = new StringBuilder();
-                
     sb.append(getLinkToPage(venue));
     sb.append(HASH);
     sb.append(venue.getID());
+    return sb.toString();
+  }
+
+  // These are the internal links, not shared. They go to the named anchor on the page.
+  public String getInternalLinkTo(final Show show) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getLinkToPage(show));
+    sb.append(HASH);
+    sb.append(show.getID());
+    return sb.toString();
+  }
+
+  // This now links to the redirect page for this Artist. Copy/paste a link on any page will be one of these.
+  public String getLinkTo(final Artist artist) {
+    StringBuilder sb = new StringBuilder();
+
+    sb.append(getDirectoryPath(ARTIST_DIR));
+    sb.append(artist.getID());
+    sb.append(HTML_EXT);
                 
     return sb.toString();
   }
         
+  // This now links to the redirect page for this Venue. Copy/paste a link on any page will be one of these.
+  public String getLinkTo(final Venue venue) {
+    StringBuilder sb = new StringBuilder();
+                
+    sb.append(getDirectoryPath(VENUE_DIR));
+    sb.append(venue.getID());
+    sb.append(HTML_EXT);
+                
+    return sb.toString();
+  }
+        
+  // This now links to the redirect page for this Show. Copy/paste a link on any page will be one of these.
   public String getLinkTo(final Show show) {
     StringBuilder sb = new StringBuilder();
                 
-    sb.append(getLinkToPage(show));
-    sb.append(HASH);
+    sb.append(getDirectoryPath(SHOW_DIR));
     sb.append(show.getID());
+    sb.append(HTML_EXT);
                 
     return sb.toString();
   }

--- a/src/com/bolsinga/web/RecordDocumentCreator.java
+++ b/src/com/bolsinga/web/RecordDocumentCreator.java
@@ -38,7 +38,7 @@ public abstract class RecordDocumentCreator implements Backgroundable {
   
   protected void create(final RecordFactory factory) {
     Document d = populate(factory);
-    writeDocument(factory, d);
+    writeDocument(factory.getFilePath(), d);
   }
   
   protected Document populate(final RecordFactory factory) {
@@ -56,6 +56,23 @@ public abstract class RecordDocumentCreator implements Backgroundable {
     return d;
   }
   
+  public void createRedirectDocument(final RedirectFactory factory) {
+    Document d = new Document(ECSDefaults.getDefaultCodeset());
+
+    d.getHtml().setPrettyPrint(true);
+
+    d.setDoctype(new org.apache.ecs.Doctype.Html401Strict());
+
+    Head h = d.getHead();
+    h.setPrettyPrint(true);
+
+    h.addElement(new Meta().setContent("0;url=" + factory.getInternalURL()).setHttpEquiv("refresh"));
+    h.addElement(new Meta().setContent(System.getProperty("user.name")).setName("Author"));
+    h.addElement(new Meta().setContent(getCopyright()).setName("Copyright"));
+
+    writeDocument(factory.getFilePath(), d);
+  }
+
   protected abstract String getCopyright();
   
   protected String getMainDivClass() {
@@ -124,8 +141,8 @@ public abstract class RecordDocumentCreator implements Backgroundable {
     return d;
   }
         
-  private void writeDocument(final RecordFactory factory, final Document d) {  
-    File f = new File(fOutputDir, factory.getFilePath());
+  private void writeDocument(final String filePath, final Document d) {
+    File f = new File(fOutputDir, filePath);
     File parent = new File(f.getParent());
     if (!parent.mkdirs()) {
       if (!parent.exists()) {

--- a/src/com/bolsinga/web/RedirectFactory.java
+++ b/src/com/bolsinga/web/RedirectFactory.java
@@ -1,0 +1,6 @@
+package com.bolsinga.web;
+
+public interface RedirectFactory {
+  public String getInternalURL(); // This is the URL to redirect to.
+  public String getFilePath(); // This is the file path that will redirect to the URL above.
+}


### PR DESCRIPTION
- These pages are named from their identifiers. These pages just redirect into the current page via named anchors. They are short and simple.
- This allows Site to create links for identifiers without needing to even know the name of the band or venue, nor year of the show.