### PR TITLE
Dump all missing artist IDs instead of asserting when first found.

### DIFF
--- a/src/com/bolsinga/music/data/raw/Artist.java
+++ b/src/com/bolsinga/music/data/raw/Artist.java
@@ -162,7 +162,6 @@ public class Artist implements com.bolsinga.music.data.Artist {
   }
   
   public String getID() {
-    assert fID != null : "No ID for: " + fName;
     return fID;
   }
   

--- a/src/com/bolsinga/site/Main.java
+++ b/src/com/bolsinga/site/Main.java
@@ -105,10 +105,28 @@ public class Main implements Backgroundable {
     }
   }
 
+  private boolean dumpMissingArtistIDs(final com.bolsinga.music.data.Music music) {
+    boolean displayed = false;
+    List<? extends com.bolsinga.music.data.Artist> artists = music.getArtists();
+    for (com.bolsinga.music.data.Artist artist : artists) {
+      if (artist.getID() == null) {
+        if (!displayed) {
+          System.out.println("--Artist Missing IDs--");
+          displayed = true;
+        }
+        System.out.println(artist.getName());
+      }
+    }
+    return displayed;
+  }
+
   private void generateSite(final com.bolsinga.music.data.Music music, final com.bolsinga.diary.data.Diary diary, final String output) throws Exception {
     CSS.install(output);
 
     dumpSimilarArtists(music);
+    if (dumpMissingArtistIDs(music)) {
+      throw new com.bolsinga.web.WebException("Missing Artist IDs");
+    }
 
     // Diary items
     MainDocumentCreator.createDocuments(fBackgrounder, this, diary, output, music);


### PR DESCRIPTION
This will allow clean up to occur more quickly.